### PR TITLE
Add `granularity` option to source

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This [Concourse](https://concourse-ci.org/) resource allows you to track the ver
 resource_types:
 
   - name: instana-version
-    type: docker-image
+    type: registry-image
     source:
       repository: instana/instana-version-resource
       tag: latest
@@ -26,6 +26,7 @@ resources:
     source:
       endpoint: https://awesome-tenant.instana.io
       api_token: ((instana_api_token)) # Use secrets if you can!
+      granularity: minor # optional, defaults to 'branch', one of 'branch', 'full', 'major', 'minor' or 'patch'
 ```
 
 ## Behaviour
@@ -34,7 +35,12 @@ resources:
 
 The resource will create the following file:
 
-* `release`, containing, e.g., `190`
+* `release`, containing, e.g., `191`
+* `image_tag`, the full version, e.g. `2.191.519-0`
+* `branch`, the currently deployed release branch, e.g. `191`
+* `major`, the currently deployed major version e.g. `2`
+* `minor`, the currently deployed minor version e.g. `191` 
+* `patch`, the currently deployed minor version e.g. `519-0` 
 
 ## Support
 

--- a/assets/check
+++ b/assets/check
@@ -17,14 +17,15 @@ cat > "${input_file}" <&0
 # Delete trailing `/`, as it can create issues when composing URLs later
 readonly endpoint=$(jq -r .source.endpoint < "${input_file}" | sed "s,/$,,")
 readonly api_token=$(jq -r .source.api_token < "${input_file}")
+readonly granularity=$(jq -r '.source.granularity // "branch"' < "${input_file}")
 
 readonly URL_REGEXP='https?://[-A-Za-z0-9\.]+(:[0-9]+)?'
 
 if [ -z "${endpoint}" ]; then
     echo "Invalid payload: missing 'endpoint'"
     exit 1
-elif ! [[ "${endpoint}" =~ ${URL_REGEXP} ]]; then 
-    echo "Invalid payload: the value '${endpoint}' for 'endpoint' is not valid; endpoint must match the followinf regex: ${URL_REGEXP}"
+elif ! [[ "${endpoint}" =~ ${URL_REGEXP} ]]; then
+    echo "Invalid payload: the value '${endpoint}' for 'endpoint' is not valid; endpoint must match the following regex: ${URL_REGEXP}"
     exit 1
 fi
 
@@ -35,4 +36,37 @@ fi
 
 echo "Using the API endpoint: ${endpoint}/api/instana/version"
 
-curl --silent --show-error --fail --header "Authorization: apiToken ${api_token}" "${endpoint}/api/instana/version" | jq -e '.branch' | sed s/release-// | jq '[{ release: . }]' >&3
+readonly data=$(curl --silent --show-error --fail --header "Authorization: apiToken ${api_token}" "${endpoint}/api/instana/version")
+readonly branch=$(echo "${data}" | jq -er '.branch' | sed s/release-//)
+
+readonly imageTag=$(echo "${data}" | jq -er '.imageTag')
+readonly versions=( ${imageTag//./ } )
+
+readonly major="${versions[0]}"
+readonly minor="${versions[1]}"
+readonly patch="${versions[2]}"
+
+version=""
+case "$granularity" in
+   branch)
+      version="${branch}"
+     ;;
+   full)
+     version="${imageTag}"
+     ;;
+   major)
+     version="${major}"
+     ;;
+   minor)
+     version="${major}.${minor}"
+     ;;
+   patch)
+     version="${major}.${minor}.${patch}"
+     ;;
+   *)
+     echo "Invalid granularity '$granularity'. Must be one of 'branch', 'full', 'major', 'minor' or 'patch'."
+     exit 1
+     ;;
+esac
+
+echo "[{ \"release\": \"$version\" }]" >&3

--- a/assets/check
+++ b/assets/check
@@ -46,10 +46,9 @@ readonly major="${versions[0]}"
 readonly minor="${versions[1]}"
 readonly patch="${versions[2]}"
 
-version=""
-case "$granularity" in
+case "${granularity}" in
    branch)
-      version="${branch}"
+     version="${branch}"
      ;;
    full)
      version="${imageTag}"

--- a/assets/in
+++ b/assets/in
@@ -55,10 +55,9 @@ readonly major="${versions[0]}"
 readonly minor="${versions[1]}"
 readonly patch="${versions[2]}"
 
-version=""
-case "$granularity" in
+case "${granularity}" in
    branch)
-      version="${branch}"
+     version="${branch}"
      ;;
    full)
      version="${imageTag}"

--- a/assets/in
+++ b/assets/in
@@ -26,14 +26,15 @@ cat > "${input_file}" <&0
 # Delete trailing `/`, as it can create issues when composing URLs later
 readonly endpoint=$(jq -r .source.endpoint < "${input_file}" | sed "s,/$,,")
 readonly api_token=$(jq -r .source.api_token < "${input_file}")
+readonly granularity=$(jq -r '.source.granularity // "branch"' < "${input_file}")
 
 readonly URL_REGEXP='https?://[-A-Za-z0-9\.]+(:[0-9]+)?'
 
 if [ -z "${endpoint}" ]; then
     echo "Invalid payload: missing 'endpoint'"
     exit 1
-elif ! [[ "${endpoint}" =~ ${URL_REGEXP} ]]; then 
-    echo "Invalid payload: the value '${endpoint}' for 'endpoint' is not valid; endpoint must match the followinf regex: ${URL_REGEXP}"
+elif ! [[ "${endpoint}" =~ ${URL_REGEXP} ]]; then
+    echo "Invalid payload: the value '${endpoint}' for 'endpoint' is not valid; endpoint must match the following regex: ${URL_REGEXP}"
     exit 1
 fi
 
@@ -45,10 +46,44 @@ fi
 echo "Using the API endpoint: ${endpoint}/api/instana/version"
 
 readonly data=$(curl --silent --show-error --fail --header "Authorization: apiToken ${api_token}" "${endpoint}/api/instana/version")
+readonly branch=$(echo "${data}" | jq -er '.branch' | sed s/release-//)
 
-readonly version=$(echo "${data}" | jq -er '.branch' | sed s/release-//)
+readonly imageTag=$(echo "${data}" | jq -er '.imageTag')
+readonly versions=( ${imageTag//./ } )
+
+readonly major="${versions[0]}"
+readonly minor="${versions[1]}"
+readonly patch="${versions[2]}"
+
+version=""
+case "$granularity" in
+   branch)
+      version="${branch}"
+     ;;
+   full)
+     version="${imageTag}"
+     ;;
+   major)
+     version="${major}"
+     ;;
+   minor)
+     version="${major}.${minor}"
+     ;;
+   patch)
+     version="${major}.${minor}.${patch}"
+     ;;
+   *)
+     echo "Invalid granularity '$granularity'. Must be one of 'branch', 'full', 'major', 'minor' or 'patch'."
+     exit 1
+     ;;
+esac
 
 echo "${version}" > "${destination}/release"
+echo "${imageTag}" > "${destination}/image_tag"
+echo "${branch}" > "${destination}/branch"
+echo "${major}" > "${destination}/major"
+echo "${minor}" > "${destination}/minor"
+echo "${patch}" > "${destination}/patch"
 
 jq -n "{
   \"version\": {
@@ -58,6 +93,26 @@ jq -n "{
     {
       \"name\": \"version\",
       \"value\": \"${version}\"
+    },
+    {
+      \"name\": \"patch\",
+      \"value\": \"${patch}\"
+    },
+    {
+      \"name\": \"minor\",
+      \"value\": \"${minor}\"
+    },
+    {
+      \"name\": \"major\",
+      \"value\": \"${major}\"
+    },
+    {
+      \"name\": \"branch\",
+      \"value\": \"${branch}\"
+    },
+    {
+      \"name\": \"image_tag\",
+      \"value\": \"${imageTag}\"
     }
   ]
 }" >&3


### PR DESCRIPTION
This introduces the `granularity` setting, which configures how granular new versions should be created.

The default value is `branch`, which is the behaviour that shipped with 0.0.1.

Full list of options:
 * 'branch' e.g. `191` => `191`
 * 'full' e.g. `2.191.123-0` => `2.191.123-0`
 * 'major' e.g. `2` => `2`
 * 'minor' e.g. `191` => `2.191`
 * 'patch' e.g. `123-0` => `2.191.123-0`

Though `branch` and `full` would normally correspond to the value of `minor` and `full` respectively, there could be exceptions.