### PR TITLE
Introduce 'format' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,39 @@ resources:
     source:
       endpoint: https://awesome-tenant.instana.io
       api_token: ((instana_api_token)) # Use secrets if you can!
-      granularity: minor # optional, defaults to 'branch', one of 'branch', 'full', 'major', 'minor' or 'patch'
+      granularity: minor # optional, defaults to ""; valid values are: 'branch', 'full', 'major', 'minor' or 'patch'
+      format: # optional, defaults to "%branch%"
 ```
 
 ## Behaviour
 
 ### In
 
+Supports the following parameters:
+
+* `format` provides a formatting pattern for the release.
+  The following tokens are replaced in the provided format string:
+  * `%branch%` will be replaced with the currently deployed release branch, e.g. `191`
+  * `%full%` will be replaced with the currently deployed major version e.g. `2`
+  * `%major%` will be replaced with the currently deployed minor version e.g. `191`
+  * `%patch%` will be replaced with the currently deployed patch version e.g. `519-0`
+
+* `granularity` provides short-hands for `format` as follows:
+  * `branch` -> `%branch%`
+  * `full` -> `%full%`
+  * `major` -> `%major%.%minor%`
+  * `patch` -> `%major%.%minor%.%patch%`
+
+**Note:** Using both `format` and `granularity` is not allowed, and the resource will fail.
+
 The resource will create the following file:
 
-* `release`, containing, e.g., `191`
+* `release`, containing the formatted version based on the value of the `format` parameter
 * `image_tag`, the full version, e.g. `2.191.519-0`
 * `branch`, the currently deployed release branch, e.g. `191`
 * `major`, the currently deployed major version e.g. `2`
-* `minor`, the currently deployed minor version e.g. `191` 
-* `patch`, the currently deployed minor version e.g. `519-0` 
+* `minor`, the currently deployed minor version e.g. `191`
+* `patch`, the currently deployed patch version e.g. `519-0`
 
 ## Support
 

--- a/assets/in
+++ b/assets/in
@@ -26,21 +26,27 @@ cat > "${input_file}" <&0
 # Delete trailing `/`, as it can create issues when composing URLs later
 readonly endpoint=$(jq -r .source.endpoint < "${input_file}" | sed "s,/$,,")
 readonly api_token=$(jq -r .source.api_token < "${input_file}")
-readonly granularity=$(jq -r '.source.granularity // "branch"' < "${input_file}")
+readonly granularity=$(jq -r '.source.granularity // ""' < "${input_file}")
+format=$(jq -r '.source.format // ""' < "${input_file}")
 
 readonly URL_REGEXP='https?://[-A-Za-z0-9\.]+(:[0-9]+)?'
 
 if [ -z "${endpoint}" ]; then
-    echo "Invalid payload: missing 'endpoint'"
-    exit 1
+  echo "Invalid payload: missing 'endpoint'"
+  exit 1
 elif ! [[ "${endpoint}" =~ ${URL_REGEXP} ]]; then
-    echo "Invalid payload: the value '${endpoint}' for 'endpoint' is not valid; endpoint must match the following regex: ${URL_REGEXP}"
-    exit 1
+  echo "Invalid payload: the value '${endpoint}' for 'endpoint' is not valid; endpoint must match the following regex: ${URL_REGEXP}"
+  exit 1
 fi
 
 if [ -z "${api_token}" ]; then
-    echo "Invalid payload: missing 'api_token'"
-    exit 1
+  echo "Invalid payload: missing 'api_token'"
+  exit 1
+fi
+
+if [ -n "${format}" ] && [ -n "${granularity}" ]; then
+  echo "Both 'format' and 'granularity' have been specified, invalid configuration"
+  exit 1
 fi
 
 echo "Using the API endpoint: ${endpoint}/api/instana/version"
@@ -55,27 +61,40 @@ readonly major="${versions[0]}"
 readonly minor="${versions[1]}"
 readonly patch="${versions[2]}"
 
-case "${granularity}" in
-   branch)
-     version="${branch}"
-     ;;
-   full)
-     version="${imageTag}"
-     ;;
-   major)
-     version="${major}"
-     ;;
-   minor)
-     version="${major}.${minor}"
-     ;;
-   patch)
-     version="${major}.${minor}.${patch}"
-     ;;
-   *)
-     echo "Invalid granularity '$granularity'. Must be one of 'branch', 'full', 'major', 'minor' or 'patch'."
-     exit 1
-     ;;
-esac
+if [ -n "${granularity}" ]; then
+  case "${granularity}" in
+  branch)
+    format='%branch%'
+    ;;
+  full)
+    format='%full%'
+    ;;
+  major)
+    format='%major%'
+    ;;
+  minor)
+    format='%major%.%minor%'
+    ;;
+  patch)
+    format='%major%.%minor%.%patch%'
+    ;;
+  *)
+    echo "Invalid granularity '$granularity'. Must be one of 'branch', 'full', 'major', 'minor' or 'patch'."
+    exit 1
+    ;;
+  esac
+fi
+
+if [ -z "${format}" ]; then
+  format='%branch%'
+fi
+
+version="${format}"
+version="${version//%branch%/${branch}}"
+version="${version//%full%/${imageTag}}"
+version="${version//%major%/${major}}"
+version="${version//%minor%/${minor}}"
+version="${version//%patch%/${patch}}"
 
 echo "${version}" > "${destination}/release"
 echo "${imageTag}" > "${destination}/image_tag"


### PR DESCRIPTION
Introduce a `format` option, more flexible than `granularity` (which is kept as syntactic sugar for `format`) that enabled the specification of a formatting pattern, in which the following tokens are replaced:

  * `%branch%` will be replaced with the currently deployed release branch, e.g. `191`
  * `%full%` will be replaced with the currently deployed major version e.g. `2`
  * `%major%` will be replaced with the currently deployed minor version e.g. `191`
  * `%patch%` will be replaced with the currently deployed patch version e.g. `519-0`